### PR TITLE
Change default timezone to Etc/UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- Change default timezone to Etc/UTC
+
 ### Added
 
 - …

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -27,7 +27,7 @@ parameters:
     backofflimit: '2'
     annotation: k8up.syn.tools/backup
     backupcommandannotation: k8up.syn.tools/backupcommand
-    tz: Europe/Zurich
+    tz: Etc/UTC
     alert_rule_filters:
       namespace: namespace=~"syn.*"
     prometheus_push_gateway: 'http://platform-prometheus-pushgateway.syn-synsights.svc:9091'

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -96,7 +96,7 @@ default:: `k8up.syn.tools/backupcommand`
 
 [horizontal]
 type:: string
-default:: `Europe/Zurich`
+default:: `Etc/UTC`
 
 == `alert_rule_filters`
 


### PR DESCRIPTION
Having Europe/Zurich as default timezone will cause
issues in the future as this doesn't make sense for systems
outside of Switzerland and is not a valid default for
a public component.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

