### PR TITLE
Revert "Update wrestic default version to v0.2.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 
-- Bump wrestic image to v0.2.0 ([#3])
 - Conditional import of Crossplane lib ([#2])
 
 [Unreleased]: https://github.com/projectsyn/component-backup-k8up/compare/a73e2f519e7777a24beeeac43449cd805aa5b946...HEAD
 
 [#2]: https://github.com/projectsyn/component-backup-k8up/pull/2
-[#3]: https://github.com/projectsyn/component-backup-k8up/pull/3

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -40,4 +40,4 @@ parameters:
         tag: 'v0.1.10@sha256:74ef61f26c85b4a6ab6b02761caefe6d59234db559f7ed6bb7430f345b7ac488'
       wrestic:
         image: docker.io/vshn/wrestic
-        tag: 'v0.2.0@sha256:b2c75ab4a444a4926855c3a264e330e3a6d6a72e586419c1809b48555277dff9'
+        tag: 'v0.1.9@sha256:6b756ddb70e15977fc3d53a0468bcf6386d79d989768d48696167161f20e115e'


### PR DESCRIPTION
This reverts commit 87401e0513095613793800f65ed37835864c93c6.

We observed backups getting stuck with wrestic v0.2.0, so we're globally
reverting the version bump.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
