### PR TITLE
New more generic alert filtering

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -29,7 +29,8 @@ parameters:
     backupcommandannotation: k8up.syn.tools/backupcommand
     tz: Europe/Zurich
     alert_rule_filters:
-      namespace: namespace=~"syn.*"
+      namespace:
+        match_re: "syn.*"
     prometheus_push_gateway: 'http://platform-prometheus-pushgateway.syn-synsights.svc:9091'
     monitoring_enabled: true
     charts:

--- a/component/monitoring.jsonnet
+++ b/component/monitoring.jsonnet
@@ -30,6 +30,29 @@ local service_monitor = com.namespaced(params.namespace, {
   },
 });
 
+local alert_selector(filters) =
+  local op = {
+    exclude: '!=',
+    exclude_re: '!~',
+    match: '=',
+    match_re: '=~',
+  };
+  local selector(sel) = [
+    {
+      op: op[s],
+      val: sel[s],
+    }
+    for s in std.objectFields(sel)
+  ];
+  if filters != null then
+    local selectors = std.mapWithKey(
+      function(key, sel) ([ '%s%s"%s"' % [ key, s.op, s.val ] for s in selector(sel) ]),
+      filters
+    );
+    std.join(',', std.flattenArrays([ selectors[f] for f in std.objectFields(selectors) ]))
+  else
+    '';
+
 local alert_rules = com.namespaced(params.namespace, {
   apiVersion: 'monitoring.coreos.com/v1',
   kind: 'PrometheusRule',
@@ -50,8 +73,7 @@ local alert_rules = com.namespaced(params.namespace, {
             annotations: {
               message: 'Last backup for PVC {{ $labels.pvc }} in namespace {{ $labels.instance }} had {{ $value }} errors',
             },
-            expr: 'baas_backup_restic_last_errors{%s} > 0' %
-                  com.getValueOrDefault(params.alert_rule_filters, 'namespace', ''),
+            expr: 'baas_backup_restic_last_errors{%s} > 0' % alert_selector(params.alert_rule_filters),
             'for': '1m',
             labels: {
               severity: 'critical',


### PR DESCRIPTION
Allows filtering on arbitrary metric labels, programmatically constructs the filter based on entries in alert_rule_filters.

Format:
* key in alert_rule_filters indicates label on which to filter.
* each entry in alert_rule filters expects another dict as value
* Entry dicts support keys `match`, `match_re`, `exclude` and
  `exclude_re` which are mapped to '=', '=~', '!=' and '!~' respectively.
* Values for the operation keys are reproduced verbatim wrapped in
  double quotes.

PoC / WIP implementation for #7 

## Checklist

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [ ] Update the ./CHANGELOG.md.
- [ ] Link this PR to related issues.
