### PR TITLE
Reduce time a K8up job needs to be queued to raise an alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switch docker registry from docker.io to quay.io ([#14])
 - Option to disable the component
 - Move alert definitions to parameters ([#18])
+- Adjust K8upJobStuck alert configuration ([#10])
 
 [Unreleased]: https://github.com/projectsyn/component-backup-k8up/compare/a73e2f519e7777a24beeeac43449cd805aa5b946...HEAD
 
 [#2]: https://github.com/projectsyn/component-backup-k8up/pull/2
 [#6]: https://github.com/projectsyn/component-backup-k8up/pull/6
+[#10]: https://github.com/projectsyn/component-backup-k8up/pull/10
 [#11]: https://github.com/projectsyn/component-backup-k8up/pull/11
 [#14]: https://github.com/projectsyn/component-backup-k8up/pull/14
 [#18]: https://github.com/projectsyn/component-backup-k8up/pull/18

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -61,9 +61,9 @@ parameters:
           severity: critical
       K8upJobStuck:
         annotations:
-          message: K8up jobs are stuck in {{ $labels.exported_namespace }} for the last 24 hours.
+          message: Queued K8up jobs in {{ $labels.exported_namespace }} for the last hour.
         expr: k8up_jobs_queued_gauge{jobType="backup"} > 0 and on(namespace) k8up_schedules_gauge > 0
-        for: 24h
+        for: 1h
         labels:
           severity: critical
     charts:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -174,9 +174,9 @@ K8upBackupNotRunning:
     severity: critical
 K8upJobStuck:
   annotations:
-    message: K8up jobs are stuck in {{ $labels.exported_namespace }} for the last 24 hours.
+    message: Queued K8up jobs in {{ $labels.exported_namespace }} for the last hour.
   expr: k8up_jobs_queued_gauge{jobType="backup"} > 0 and on(namespace) k8up_schedules_gauge > 0
-  for: 24h
+  for: 1h
   labels:
     severity: critical
 ----


### PR DESCRIPTION
With the old alert configuration, alerts would only be raised after ~48h, leading to a high likelihood that more than one scheduled backup was missed (assuming daily backups).


## Checklist
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.
