### PR TITLE
Introduce parameter for configuring the Prometheus name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Introduce paramter for confiugring the Prometheus name ([#11])
+
 ### Changed
 
 - Conditional import of Crossplane lib ([#2])
@@ -14,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#2]: https://github.com/projectsyn/component-backup-k8up/pull/2
 [#6]: https://github.com/projectsyn/component-backup-k8up/pull/6
+[#11]: https://github.com/projectsyn/component-backup-k8up/pull/11

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -31,6 +31,7 @@ parameters:
     alert_rule_filters:
       namespace: namespace=~"syn.*"
     prometheus_push_gateway: 'http://platform-prometheus-pushgateway.syn-synsights.svc:9091'
+    prometheus_name: main
     monitoring_enabled: true
     charts:
       k8up: 0.6.1

--- a/component/monitoring.jsonnet
+++ b/component/monitoring.jsonnet
@@ -36,7 +36,7 @@ local alert_rules = com.namespaced(params.namespace, {
   metadata: {
     name: 'k8up',
     labels: {
-      prometheus: inv.parameters.synsights.prometheus.name,
+      prometheus: params.prometheus_name,
       role: 'alert-rules',
     },
   },

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -110,6 +110,22 @@ default:: `{'namespace': 'namespace=~"syn.*"'}
 type:: string
 default:: `'http://platform-prometheus-pushgateway.syn-synsights.svc:9091'`
 
+== `prometheus_name`
+
+[horizontal]
+type:: string
+default:: `'main'`
+
+PrometheusRule objects get the label `prometheus`.
+This label will be used by the Prometheus operator to select the rules to render for a prometheus instance.
+This parameter allows to set the value of that label.
+
+[NOTE]
+====
+If the component Synsights is being used, ensure that this value matches with `parameters.synsights.prometheus.name`.
+It is suggested to do this within you global configuration hierarchy.
+====
+
 == `monitoring_enabled`
 
 [horizontal]


### PR DESCRIPTION
Directly access variables of other components create implicit dependencies. Instead each component must define their own parameters with or without defaults. It is then the responsibility of the config hierarchy to glue components together.

This PR removes the use of `parameters.synsights.prometheus.name` and replaces it with `prometheus_name` owned by this component.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
