### PR TITLE
Switch docker registry from docker.io to quay.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Conditional import of Crossplane lib ([#2])
 - Allow restic alert filter to be null ([#6])
+- Switch docker registry from docker.io to quay.io ([#14])
 
 [Unreleased]: https://github.com/projectsyn/component-backup-k8up/compare/a73e2f519e7777a24beeeac43449cd805aa5b946...HEAD
 
 [#2]: https://github.com/projectsyn/component-backup-k8up/pull/2
 [#6]: https://github.com/projectsyn/component-backup-k8up/pull/6
 [#11]: https://github.com/projectsyn/component-backup-k8up/pull/11
+[#14]: https://github.com/projectsyn/component-backup-k8up/pull/14

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -37,8 +37,8 @@ parameters:
       k8up: 0.6.1
     images:
       k8up:
-        image: docker.io/vshn/k8up
+        image: quay.io/vshn/k8up
         tag: 'v0.1.10@sha256:74ef61f26c85b4a6ab6b02761caefe6d59234db559f7ed6bb7430f345b7ac488'
       wrestic:
-        image: docker.io/vshn/wrestic
+        image: quay.io/vshn/wrestic
         tag: 'v0.1.9@sha256:6b756ddb70e15977fc3d53a0468bcf6386d79d989768d48696167161f20e115e'


### PR DESCRIPTION
Docker Hub has introduced a rate limit for docker pulls,
so solve this for all, this switches the registry to quay.io.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
