### PR TITLE
Move alert definitions to parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow restic alert filter to be null ([#6])
 - Switch docker registry from docker.io to quay.io ([#14])
 - Option to disable the component
+- Move alert definitions to parameters ([#18])
 
 [Unreleased]: https://github.com/projectsyn/component-backup-k8up/compare/a73e2f519e7777a24beeeac43449cd805aa5b946...HEAD
 
@@ -21,3 +22,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#6]: https://github.com/projectsyn/component-backup-k8up/pull/6
 [#11]: https://github.com/projectsyn/component-backup-k8up/pull/11
 [#14]: https://github.com/projectsyn/component-backup-k8up/pull/14
+[#18]: https://github.com/projectsyn/component-backup-k8up/pull/18

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -37,6 +37,35 @@ parameters:
     prometheus_push_gateway: 'http://platform-prometheus-pushgateway.syn-synsights.svc:9091'
     prometheus_name: main
     monitoring_enabled: true
+    monitoring_alerts:
+      - alert: k8up_last_errors
+        annotations:
+          message: Last backup for PVC {{ $labels.pvc }} in namespace {{ $labels.instance }} had {{ $value }} errors
+        expr: baas_backup_restic_last_errors{${backup_k8up:alert_rule_filters:namespace}} > 0
+        for: 1m
+        labels:
+          severity: critical
+      - alert: K8upBackupFailed
+        annotations:
+          message: Job in {{ $labels.exported_namespace }} of type {{ $labels.jobType }} failed
+        expr: rate(k8up_jobs_failed_counter[1d]) > 0
+        for: 1m
+        labels:
+          severity: critical
+      - alert: K8upBackupNotRunning
+        annotations:
+          message: No K8up jobs were run in {{ $labels.exported_namespace }} within the last 24 hours. Check the operator, there might be a deadlock
+        expr: sum(rate(k8up_jobs_total[25h])) == 0 and on(namespace) k8up_schedules_gauge > 0
+        for: 1m
+        labels:
+          severity: critical
+      - alert: K8upJobStuck
+        annotations:
+          message: K8up jobs are stuck in {{ $labels.exported_namespace }} for the last 24 hours.
+        expr: k8up_jobs_queued_gauge{jobType="backup"} > 0 and on(namespace) k8up_schedules_gauge > 0
+        for: 24h
+        labels:
+          severity: critical
     charts:
       k8up: 0.6.1
     images:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -38,28 +38,28 @@ parameters:
     prometheus_name: main
     monitoring_enabled: true
     monitoring_alerts:
-      - alert: k8up_last_errors
+      k8up_last_errors:
         annotations:
           message: Last backup for PVC {{ $labels.pvc }} in namespace {{ $labels.instance }} had {{ $value }} errors
         expr: baas_backup_restic_last_errors{${backup_k8up:alert_rule_filters:namespace}} > 0
         for: 1m
         labels:
           severity: critical
-      - alert: K8upBackupFailed
+      K8upBackupFailed:
         annotations:
           message: Job in {{ $labels.exported_namespace }} of type {{ $labels.jobType }} failed
         expr: rate(k8up_jobs_failed_counter[1d]) > 0
         for: 1m
         labels:
           severity: critical
-      - alert: K8upBackupNotRunning
+      K8upBackupNotRunning:
         annotations:
           message: No K8up jobs were run in {{ $labels.exported_namespace }} within the last 24 hours. Check the operator, there might be a deadlock
         expr: sum(rate(k8up_jobs_total[25h])) == 0 and on(namespace) k8up_schedules_gauge > 0
         for: 1m
         labels:
           severity: critical
-      - alert: K8upJobStuck
+      K8upJobStuck:
         annotations:
           message: K8up jobs are stuck in {{ $labels.exported_namespace }} for the last 24 hours.
         expr: k8up_jobs_queued_gauge{jobType="backup"} > 0 and on(namespace) k8up_schedules_gauge > 0

--- a/component/monitoring.jsonnet
+++ b/component/monitoring.jsonnet
@@ -45,7 +45,10 @@ local alert_rules = com.namespaced(params.namespace, {
     groups: [
       {
         name: 'k8up.rules',
-        rules: params.monitoring_alerts,
+        rules: [
+          { alert: field } + params.monitoring_alerts[field]
+          for field in std.sort(std.objectFields(params.monitoring_alerts))
+        ],
       },
     ],
   },

--- a/component/monitoring.jsonnet
+++ b/component/monitoring.jsonnet
@@ -45,53 +45,7 @@ local alert_rules = com.namespaced(params.namespace, {
     groups: [
       {
         name: 'k8up.rules',
-        rules: [
-          {
-            alert: 'k8up_last_errors',
-            annotations: {
-              message: 'Last backup for PVC {{ $labels.pvc }} in namespace {{ $labels.instance }} had {{ $value }} errors',
-            },
-            expr: 'baas_backup_restic_last_errors{%s} > 0' %
-                  com.getValueOrDefault(params.alert_rule_filters, 'namespace', ''),
-            'for': '1m',
-            labels: {
-              severity: 'critical',
-            },
-          },
-          {
-            alert: 'K8upBackupFailed',
-            expr: 'rate(k8up_jobs_failed_counter[1d]) > 0',
-            'for': '1m',
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
-              message: 'Job in {{ $labels.exported_namespace }} of type {{ $labels.jobType }} failed',
-            },
-          },
-          {
-            alert: 'K8upBackupNotRunning',
-            expr: 'sum(rate(k8up_jobs_total[25h])) == 0 and on(namespace) k8up_schedules_gauge > 0',
-            'for': '1m',
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
-              message: 'No K8up jobs were run in {{ $labels.exported_namespace }} within the last 24 hours. Check the operator, there might be a deadlock',
-            },
-          },
-          {
-            alert: 'K8upJobStuck',
-            expr: 'k8up_jobs_queued_gauge{jobType="backup"} > 0 and on(namespace) k8up_schedules_gauge > 0',
-            'for': '24h',
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
-              message: 'K8up jobs are stuck in {{ $labels.exported_namespace }} for the last 24 hours.',
-            },
-          },
-        ],
+        rules: params.monitoring_alerts,
       },
     ],
   },

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -143,6 +143,48 @@ It is suggested to do this within you global configuration hierarchy.
 type:: bool
 default:: `true`
 
+== `monitoring_alerts`
+
+[horizontal]
+type:: dict
+default::
++
+[source,yaml]
+----
+k8up_last_errors:
+  annotations:
+    message: Last backup for PVC {{ $labels.pvc }} in namespace {{ $labels.instance }} had {{ $value }} errors
+  expr: baas_backup_restic_last_errors{${backup_k8up:alert_rule_filters:namespace}} > 0
+  for: 1m
+  labels:
+    severity: critical
+K8upBackupFailed:
+  annotations:
+    message: Job in {{ $labels.exported_namespace }} of type {{ $labels.jobType }} failed
+  expr: rate(k8up_jobs_failed_counter[1d]) > 0
+  for: 1m
+  labels:
+    severity: critical
+K8upBackupNotRunning:
+  annotations:
+    message: No K8up jobs were run in {{ $labels.exported_namespace }} within the last 24 hours. Check the operator, there might be a deadlock
+  expr: sum(rate(k8up_jobs_total[25h])) == 0 and on(namespace) k8up_schedules_gauge > 0
+  for: 1m
+  labels:
+    severity: critical
+K8upJobStuck:
+  annotations:
+    message: K8up jobs are stuck in {{ $labels.exported_namespace }} for the last 24 hours.
+  expr: k8up_jobs_queued_gauge{jobType="backup"} > 0 and on(namespace) k8up_schedules_gauge > 0
+  for: 24h
+  labels:
+    severity: critical
+----
+
+Alert definitions to deploy in a `PrometheusRule` object.
+The dict is transformed to a list of alerting rules by the component.
+Keys in the dict are used to add the field `alert: <key>` to each resulting alerting rule.
+This structure is chosen to easily adjust individual alert configurations in the hierarchy.
 
 == Example
 
@@ -158,4 +200,8 @@ global_s3restore_credentials:
   secretkey: '?{vaultkv:${customer:name}/${cluster:name}/global-backup/restore-secret-key}'
 global_restore_s3endpoint: https://s3endpoint.example.com
 global_restore_bucket: example-restore-bucket
+monitoring_alerts:
+  K8upJobStuck:
+    annotations:
+      runbook_url: https://example.com/k8up_runbook.md
 ----


### PR DESCRIPTION
Moving the alert definitions to `parameters.backup_k8up.monitoring_alerts` allows users of the component to selectively adjust/replace/extend the set of alerts which are deployed for K8up.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
