### PR TITLE
Add alert to warn about slow backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Introduce paramter for confiugring the Prometheus name ([#11])
+- Add alert for slow backup jobs ([#19])
 
 ### Changed
 
@@ -25,3 +26,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#11]: https://github.com/projectsyn/component-backup-k8up/pull/11
 [#14]: https://github.com/projectsyn/component-backup-k8up/pull/14
 [#18]: https://github.com/projectsyn/component-backup-k8up/pull/18
+[#19]: https://github.com/projectsyn/component-backup-k8up/pull/19

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -37,6 +37,8 @@ parameters:
     prometheus_push_gateway: 'http://platform-prometheus-pushgateway.syn-synsights.svc:9091'
     prometheus_name: main
     monitoring_enabled: true
+    alert_thresholds:
+      k8up_slow_backup_job_duration_seconds: 1200
     monitoring_alerts:
       k8up_last_errors:
         annotations:
@@ -66,6 +68,13 @@ parameters:
         for: 1h
         labels:
           severity: critical
+      K8upSlowBackup:
+        annotations:
+          message: Backup job {{ $labels.job_name }} in {{ $labels.namespace }} took {{ $value|humanizeDuration }} to complete
+        expr: (kube_job_status_completion_time{job_name=~"^backupjob-.*$"} - kube_job_status_start_time) > ${backup_k8up:alert_thresholds:k8up_slow_backup_job_duration_seconds}
+        for: 1m
+        labels:
+          severity: warning
     charts:
       k8up: 0.6.1
     images:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -143,6 +143,23 @@ It is suggested to do this within you global configuration hierarchy.
 type:: bool
 default:: `true`
 
+
+== `alert_thresholds`
+
+[horizontal]
+type:: dict
+default::
++
+[source,yaml]
+----
+k8up_slow_backup_job_duration_seconds: 1200
+----
+
+Dict which holds configuration values for the alerts in `monitoring_alerts`.
+This allows users to make alert expressions configurable without having to copy-paste the entire Prometheus query.
+
+* `k8up_slow_backup_job_duration_seconds` configures the threshold in seconds above which alerts are generated for "slow" backup jobs.
+
 == `monitoring_alerts`
 
 [horizontal]
@@ -179,6 +196,13 @@ K8upJobStuck:
   for: 1h
   labels:
     severity: critical
+K8upSlowBackup:
+  annotations:
+    message: Backup job {{ $labels.job_name }} in {{ $labels.namespace }} took {{ $value|humanizeDuration }} to complete
+  expr: (kube_job_status_completion_time{job_name=~"^backupjob-.*$"} - kube_job_status_start_time) > ${backup_k8up:alert_thresholds:k8up_slow_backup_job_duration_seconds}
+  for: 1m
+  labels:
+    severity: warning
 ----
 
 Alert definitions to deploy in a `PrometheusRule` object.


### PR DESCRIPTION
By default, alert for backups which take longer than 30 minutes

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
