### PR TITLE
Prepare release for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.0.0]
 ### Added
+- Initial implementation
 - Introduce paramter for confiugring the Prometheus name ([#11])
 - Add alert for slow backup jobs ([#19])
 
@@ -18,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move alert definitions to parameters ([#18])
 - Adjust K8upJobStuck alert configuration ([#10])
 
-[Unreleased]: https://github.com/projectsyn/component-backup-k8up/compare/a73e2f519e7777a24beeeac43449cd805aa5b946...HEAD
+[Unreleased]: https://github.com/projectsyn/component-backup-k8up/compare/v1.0.0...HEAD
+[v1.0.0]: https://github.com/projectsyn/component-backup-k8up/releases/tag/v1.0.0
 
 [#2]: https://github.com/projectsyn/component-backup-k8up/pull/2
 [#6]: https://github.com/projectsyn/component-backup-k8up/pull/6


### PR DESCRIPTION
Selecting v1.0.0 over v0.1.0 because this component is already used in production all over the place.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
