### PR TITLE
Fix CRD version handling and clean up component implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.0]
+
+### Added
+
+* Re-added `image` parameters and pass them through to `helmValues` ([#23])
+
+### Changed
+
+* Switch to Helm dependency type to download K8up chart ([#23])
+* Move postprocessing filter configuration into hierarchy ([#23])
+* Bump default versions to K8up v1.0.4 and Helm chart 1.0.5 ([#23])
+
+### Fixed
+
+* Use K8up version (not Helm chart) version to fetch CRD YAML ([#23])
+
 ## [v2.0.0]
 ### Changed
 
@@ -30,9 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adjust K8upJobStuck alert configuration ([#10])
 
 
-[Unreleased]: https://github.com/projectsyn/component-backup-k8up/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/projectsyn/component-backup-k8up/compare/v2.1.0...HEAD
 [v1.0.0]: https://github.com/projectsyn/component-backup-k8up/releases/tag/v1.0.0
-[v2.0.0]: https://github.com/projectsyn/component-backup-k8up/releases/tag/v1.0.0
+[v2.0.0]: https://github.com/projectsyn/component-backup-k8up/releases/tag/v2.0.0
+[v2.1.0]: https://github.com/projectsyn/component-backup-k8up/releases/tag/v2.1.0
 
 [#2]: https://github.com/projectsyn/component-backup-k8up/pull/2
 [#6]: https://github.com/projectsyn/component-backup-k8up/pull/6
@@ -42,3 +59,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#18]: https://github.com/projectsyn/component-backup-k8up/pull/18
 [#19]: https://github.com/projectsyn/component-backup-k8up/pull/19
 [#20]: https://github.com/projectsyn/component-backup-k8up/pull/20
+[#23]: https://github.com/projectsyn/component-backup-k8up/pull/23

--- a/class/backup-k8up.yml
+++ b/class/backup-k8up.yml
@@ -6,15 +6,15 @@ parameters:
         unpack: true
         output_path: dependencies/backup-k8up/helmcharts/v${backup_k8up:charts:k8up}
       - type: https
-        source: 'https://github.com/vshn/k8up/releases/download/v${backup_k8up:charts:k8up}/${backup_k8up:crd}'
-        output_path: dependencies/backup-k8up/crds/v${backup_k8up:charts:k8up}/02_k8up_crds.yaml
+        source: https://github.com/vshn/k8up/releases/download/${backup_k8up:images:k8up:tag}/${backup_k8up:crd}
+        output_path: dependencies/backup-k8up/crds/${backup_k8up:images:k8up:tag}/02_k8up_crds.yaml
     compile:
       - input_paths:
           - backup-k8up/component/app.jsonnet
         input_type: jsonnet
         output_path: apps/
       - input_paths:
-          - dependencies/backup-k8up/crds/v${backup_k8up:charts:k8up}/
+          - dependencies/backup-k8up/crds/${backup_k8up:images:k8up:tag}/
         output_path: backup-k8up
         input_type: copy
         output_type: yaml

--- a/class/backup-k8up.yml
+++ b/class/backup-k8up.yml
@@ -33,3 +33,9 @@ parameters:
         output_type: yaml
         input_paths:
           - backup-k8up/component/main.jsonnet
+  commodore:
+    postprocess:
+      filters:
+        - type: jsonnet
+          filter: postprocess/optional_global_config.jsonnet
+          path: backup-k8up/01_k8up_helmchart/k8up/templates

--- a/class/backup-k8up.yml
+++ b/class/backup-k8up.yml
@@ -1,9 +1,10 @@
 parameters:
   kapitan:
     dependencies:
-      - type: https
-        source: 'https://charts.appuio.ch/k8up-${backup_k8up:charts:k8up}.tgz'
-        unpack: true
+      - type: helm
+        source: https://charts.appuio.ch
+        chart_name: k8up
+        version: ${backup_k8up:charts:k8up}
         output_path: dependencies/backup-k8up/helmcharts/v${backup_k8up:charts:k8up}
       - type: https
         source: https://github.com/vshn/k8up/releases/download/${backup_k8up:images:k8up:tag}/${backup_k8up:crd}
@@ -22,7 +23,7 @@ parameters:
         input_type: helm
         output_type: yaml
         input_paths:
-          - backup-k8up/helmcharts/v${backup_k8up:charts:k8up}/k8up
+          - backup-k8up/helmcharts/v${backup_k8up:charts:k8up}
         helm_values: ${backup_k8up:helmValues}
         helm_params:
           release_name: k8up

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -8,6 +8,9 @@ parameters:
     charts:
       k8up: 1.0.3
 
+    images:
+      k8up:
+        tag: v1.0.4
 
     crd: "k8up-crd.yaml" # Use k8up-crd-legacy.yaml for K8s <= 1.15 (e.g. OpenShift 3.11):
     namespace: syn-backup

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -10,7 +10,13 @@ parameters:
 
     images:
       k8up:
+        registry: quay.io
+        repository: vshn/k8up
         tag: v1.0.4
+      wrestic:
+        registry: quay.io
+        repository: vshn/wrestic
+        tag: v0.2.3
 
     crd: "k8up-crd.yaml" # Use k8up-crd-legacy.yaml for K8s <= 1.15 (e.g. OpenShift 3.11):
     namespace: syn-backup
@@ -20,6 +26,14 @@ parameters:
       k8up:
         enableLeaderElection: true
         timezone: "Etc/UTC"
+
+        image:
+          registry: ${backup_k8up:images:k8up:registry}
+          repository: ${backup_k8up:images:k8up:repository}
+          tag: ${backup_k8up:images:k8up:tag}
+        backupImage:
+          repository: ${backup_k8up:images:wrestic:registry}/${backup_k8up:images:wrestic:repository}
+          tag: ${backup_k8up:images:wrestic:tag}
 
         envVars:
           - name: BACKUP_PROMURL

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,7 +6,7 @@ parameters:
     enabled: true
 
     charts:
-      k8up: 1.0.3
+      k8up: 1.0.5
 
     images:
       k8up:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -14,6 +14,30 @@ Setting this to false, effectively disables the component from being deployed.
 
 NOTE: The manifests will still appear in the catalog, but without the ArgoCD app they won't get deployed.
 
+== `charts`
+
+[horizontal]
+type:: dict
+default:: See `class/defaults.yml`
+
+The default K8up Helm chart version to use.
+
+== `images`
+
+[horizontal]
+type:: dict
+default:: See `class/defaults.yml`
+
+The default Docker image locations and tags to use for K8up (key `k8up`) and Wrestic (key `wrestic`).
+
+Entries in this dict should be dictionaries with keys `registry`, `repository`, and `tag`.
+This structure provides the basis for https://syn.tools/syn/SDDs/0017-maintenance-with-renovate.html[dependency maintenance with Renovate].
+
+Please customize K8up and Wrestic image locations and tags in this dict
+instead of directly in `helmValues`.
+
+The value of `k8up.tag` in this dict is used by the component to select the CRD YAML to download.
+
 == `crd`
 
 [horizontal]

--- a/postprocess/filters.yml
+++ b/postprocess/filters.yml
@@ -1,9 +1,0 @@
-filters:
-  - path: backup-k8up/01_k8up_helmchart/k8up/templates
-    type: builtin
-    filter: helm_namespace
-    filterargs:
-      namespace: ${backup_k8up:namespace}
-  - output_path: backup-k8up/01_k8up_helmchart/k8up/templates
-    type: jsonnet
-    filter: optional_global_config.jsonnet


### PR DESCRIPTION
Fixes #22.

Also cleans up the component implementation to
* use the helm dependency type to fetch the K8up helm chart
* move postprocessing filter configuration into the hierarchy

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
