### PR TITLE
Upgrade k8up, new alert rules, remove deprecated keepJobs

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -119,7 +119,22 @@ parameters:
       k8up_slow_backup_job_duration_seconds: 1200
     # Create JobFailed alert rules for the following types of jobs.
     # Valid values are: ["archive", "backup", "check", "prune", "restore"]
-    job_failed_alerts_for: ["archive", "backup", "check", "prune", "restore"]
+    job_failed_alerts_for:
+      archive:
+        enabled: true
+        overrides: {}
+      backup:
+        enabled: true
+        overrides: {}
+      check:
+        enabled: true
+        overrides: {}
+      prune:
+        enabled: true
+        overrides: {}
+      restore:
+        enabled: true
+        overrides: {}
     # The template for the JobFailed alert rules.
     # %(type)s in `alert` and `expr` is replaced by the types defined in `job_failed_alerts_for`.
     job_failed_alert_template:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -117,46 +117,24 @@ parameters:
     monitoring_kube_state_metrics_job_name_label: "job_name" # Use "job" for kube-state-metrics < v1.5.0 (e.g. OpenShift 3.11):
     alert_thresholds:
       k8up_slow_backup_job_duration_seconds: 1200
+    # Create JobFailed alert rules for the following types of jobs.
+    # Valid values are: ["archive", "backup", "check", "prune", "restore"]
+    job_failed_alerts_for: ["archive", "backup", "check", "prune", "restore"]
+    # The template for the JobFailed alert rules.
+    # %(type)s in `alert` and `expr` is replaced by the types defined in `job_failed_alerts_for`.
+    job_failed_alert_template:
+      alert: K8up%(type)sFailed
+      annotations:
+        summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
+      expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="%(type)s"}) > 0
+      for: 1m
+      labels:
+        severity: critical
     monitoring_alerts:
       k8up_last_errors:
         annotations:
           message: Last backup for PVC {{ $labels.pvc }} in namespace {{ $labels.instance }} had {{ $value }} errors
         expr: baas_backup_restic_last_errors{${backup_k8up:alert_rule_filters:namespace}} > 0
-        for: 1m
-        labels:
-          severity: critical
-      K8upArchiveFailed:
-        annotations:
-          summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
-        expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="archive"}) > 0
-        for: 1m
-        labels:
-          severity: critical
-      K8upBackupFailed:
-        annotations:
-          summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
-        expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="backup"}) > 0
-        for: 1m
-        labels:
-          severity: critical
-      K8upCheckFailed:
-        annotations:
-          summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
-        expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="check"}) > 0
-        for: 1m
-        labels:
-          severity: critical
-      K8upPruneFailed:
-        annotations:
-          summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
-        expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="prune"}) > 0
-        for: 1m
-        labels:
-          severity: critical
-      K8upRestoreFailed:
-        annotations:
-          summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
-        expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="restore"}) > 0
         for: 1m
         labels:
           severity: critical

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,13 +6,13 @@ parameters:
     enabled: true
 
     charts:
-      k8up: 1.0.8
+      k8up: 1.1.0
 
     images:
       k8up:
         registry: quay.io
         repository: vshn/k8up
-        tag: v1.1.0
+        tag: v1.2.0
       wrestic:
         registry: quay.io
         repository: vshn/wrestic
@@ -64,8 +64,10 @@ parameters:
             value: '${backup_k8up:annotation}'
           - name: BACKUP_BACKUPCOMMANDANNOTATION
             value: '${backup_k8up:backupcommandannotation}'
-          - name: BACKUP_GLOBALKEEPJOBS
-            value: '${backup_k8up:global_backup_config:keepjobs}'
+          - name: BACKUP_GLOBAL_SUCCESSFUL_JOBS_HISTORY_LIMIT
+            value: '${backup_k8up:global_backup_config:successful_jobs_history_limit}'
+          - name: BACKUP_GLOBAL_FAILED_JOBS_HISTORY_LIMIT
+            value: '${backup_k8up:global_backup_config:failed_jobs_history_limit}'
           - name: BACKUP_GLOBALS3ENDPOINT
             value: '${backup_k8up:global_backup_config:s3_endpoint}'
           - name: BACKUP_GLOBALSTATSURL
@@ -97,7 +99,8 @@ parameters:
         secretkeyname: password
       restore_s3endpoint: null
       restore_bucket: null
-      keepjobs: '3'
+      successful_jobs_history_limit: '3'
+      failed_jobs_history_limit: '3'
       stats_url: null
       s3_endpoint: null
     backofflimit: '2'
@@ -108,6 +111,7 @@ parameters:
     prometheus_push_gateway: 'http://platform-prometheus-pushgateway.syn-synsights.svc:9091'
     prometheus_name: main
     monitoring_enabled: true
+    monitoring_kube_state_metrics_job_name_label: "job_name" # Use "job" for kube-state-metrics < v1.5.0 (e.g. OpenShift 3.11):
     alert_thresholds:
       k8up_slow_backup_job_duration_seconds: 1200
     monitoring_alerts:
@@ -118,10 +122,38 @@ parameters:
         for: 1m
         labels:
           severity: critical
+      K8upArchiveFailed:
+        annotations:
+          summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
+        expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="archive"}) > 0
+        for: 1m
+        labels:
+          severity: critical
       K8upBackupFailed:
         annotations:
-          message: Job in {{ $labels.exported_namespace }} of type {{ $labels.jobType }} failed
-        expr: rate(k8up_jobs_failed_counter[1d]) > 0
+          summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
+        expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="backup"}) > 0
+        for: 1m
+        labels:
+          severity: critical
+      K8upCheckFailed:
+        annotations:
+          summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
+        expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="check"}) > 0
+        for: 1m
+        labels:
+          severity: critical
+      K8upPruneFailed:
+        annotations:
+          summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
+        expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="prune"}) > 0
+        for: 1m
+        labels:
+          severity: critical
+      K8upRestoreFailed:
+        annotations:
+          summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
+        expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="restore"}) > 0
         for: 1m
         labels:
           severity: critical

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -102,8 +102,8 @@ parameters:
       restore_s3endpoint: null
       restore_bucket: null
       keepjobs: '3'
-      successful_jobs_history_limit: ''
-      failed_jobs_history_limit: ''
+      successful_jobs_history_limit: null
+      failed_jobs_history_limit: null
       stats_url: null
       s3_endpoint: null
     backofflimit: '2'

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -64,6 +64,8 @@ parameters:
             value: '${backup_k8up:annotation}'
           - name: BACKUP_BACKUPCOMMANDANNOTATION
             value: '${backup_k8up:backupcommandannotation}'
+          - name: BACKUP_GLOBALKEEPJOBS
+            value: '${backup_k8up:global_backup_config:keepjobs}'
           - name: BACKUP_GLOBAL_SUCCESSFUL_JOBS_HISTORY_LIMIT
             value: '${backup_k8up:global_backup_config:successful_jobs_history_limit}'
           - name: BACKUP_GLOBAL_FAILED_JOBS_HISTORY_LIMIT
@@ -99,8 +101,9 @@ parameters:
         secretkeyname: password
       restore_s3endpoint: null
       restore_bucket: null
-      successful_jobs_history_limit: '3'
-      failed_jobs_history_limit: '3'
+      keepjobs: '3'
+      successful_jobs_history_limit: ''
+      failed_jobs_history_limit: ''
       stats_url: null
       s3_endpoint: null
     backofflimit: '2'

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -118,7 +118,9 @@ parameters:
     alert_thresholds:
       k8up_slow_backup_job_duration_seconds: 1200
     # Create JobFailed alert rules for the following types of jobs.
-    # Valid values are: ["archive", "backup", "check", "prune", "restore"]
+    # Valid keys are: ["archive", "backup", "check", "prune", "restore"].
+    # `enabled: false` removes the alert rule.
+    # Overrides can override all fields from the `job_failed_alert_template`. The fields are overridden before interpolating %(type)s.
     job_failed_alerts_for:
       archive:
         enabled: true

--- a/component/monitoring.jsonnet
+++ b/component/monitoring.jsonnet
@@ -38,7 +38,9 @@ local render_failed_job_alert(type) =
   assert std.member(failed_job_types, type) : 'Unknown failed job type "%s"' % type;
   local alertconfig = params.job_failed_alerts_for[type];
   if alertconfig.enabled then
-    params.job_failed_alert_template + alertconfig.overrides + {
+    com.makeMergeable(params.job_failed_alert_template) +
+    com.makeMergeable(alertconfig.overrides) +
+    {
       alert: super.alert % { type: asciiTitleCase(type) },
       expr: super.expr % { type: type },
     }

--- a/component/monitoring.jsonnet
+++ b/component/monitoring.jsonnet
@@ -31,6 +31,16 @@ local service_monitor = com.namespaced(params.namespace, {
   },
 });
 
+local asciiTitleCase(str) = std.asciiUpper(str[0]) + str[1:];
+
+local failed_job_alert_rules = std.map(
+  function(type) params.job_failed_alert_template {
+    alert: params.job_failed_alert_template.alert % { type: asciiTitleCase(type) },
+    expr: params.job_failed_alert_template.expr % { type: type },
+  }
+  , params.job_failed_alerts_for
+);
+
 local alert_rules = com.namespaced(params.namespace, {
   apiVersion: 'monitoring.coreos.com/v1',
   kind: 'PrometheusRule',
@@ -48,7 +58,7 @@ local alert_rules = com.namespaced(params.namespace, {
         rules: [
           { alert: field } + params.monitoring_alerts[field]
           for field in std.sort(std.objectFields(params.monitoring_alerts))
-        ],
+        ] + failed_job_alert_rules,
       },
     ],
   },

--- a/component/monitoring.jsonnet
+++ b/component/monitoring.jsonnet
@@ -33,7 +33,9 @@ local service_monitor = com.namespaced(params.namespace, {
 
 local asciiTitleCase(str) = std.asciiUpper(str[0]) + str[1:];
 
+local failed_job_types = [ 'archive', 'backup', 'check', 'prune', 'restore' ];
 local render_failed_job_alert(type) =
+  assert std.member(failed_job_types, type) : 'Unknown failed job type "%s"' % type;
   local alertconfig = params.job_failed_alerts_for[type];
   if alertconfig.enabled then
     params.job_failed_alert_template + alertconfig.overrides + {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -132,6 +132,7 @@ default:: `null`
 
 Sets the number of old, successful jobs to keep when cleaning up, applies to all job types.
 Overrides `global_backup_config.keepjobs`.
+If neither `global_backup_config.keepjobs` nor this parameter are set, the https://k8up.io/k8up/1.2.0/references/config-reference.html[K8up default value] for the configuration is used.
 
 == `global_backup_config.failed_jobs_history_limit`
 
@@ -141,6 +142,7 @@ default:: `null`
 
 Sets the number of old, failed jobs to keep when cleaning up, applies to all job types.
 Overrides `global_backup_config.keepjobs`.
+If neither `global_backup_config.keepjobs` nor this parameter are set, the https://k8up.io/k8up/1.2.0/references/config-reference.html[K8up default value] for the configuration is used.
 
 == `global_backup_config.stats_endpoint`
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -119,19 +119,28 @@ default:: `null`
 type:: string
 default:: `3`
 
+Sets the number of old jobs to keep when cleaning up, applies to all job types.
+
 Deprecated: Use `global_backup_config.successful_jobs_history_limit` and `global_backup_config.failed_jobs_history_limit` instead.
+Overridden by `global_backup_config.successful_jobs_history_limit` and `global_backup_config.failed_jobs_history_limit` respectively.
 
 == `global_backup_config.successful_jobs_history_limit`
 
 [horizontal]
 type:: string
-default:: ``
+default:: `null`
+
+Sets the number of old, successful jobs to keep when cleaning up, applies to all job types.
+Overrides `global_backup_config.keepjobs`.
 
 == `global_backup_config.failed_jobs_history_limit`
 
 [horizontal]
 type:: string
-default:: ``
+default:: `null`
+
+Sets the number of old, failed jobs to keep when cleaning up, applies to all job types.
+Overrides `global_backup_config.keepjobs`.
 
 == `global_backup_config.stats_endpoint`
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -121,8 +121,7 @@ default:: `3`
 
 Sets the number of old jobs to keep when cleaning up, applies to all job types.
 
-Deprecated: Use `global_backup_config.successful_jobs_history_limit` and `global_backup_config.failed_jobs_history_limit` instead.
-Overridden by `global_backup_config.successful_jobs_history_limit` and `global_backup_config.failed_jobs_history_limit` respectively.
+Deprecated: Use `global_backup_config.successful_jobs_history_limit` and `global_backup_config.failed_jobs_history_limit` instead, they override `global_backup_config.keepjobs`.
 
 == `global_backup_config.successful_jobs_history_limit`
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -113,7 +113,13 @@ default:: `null`
 type:: string
 default:: `null`
 
-`global_backup_config.keepjobs`
+== `global_backup_config.successful_jobs_history_limit`
+
+[horizontal]
+type:: string
+default:: `3`
+
+== `global_backup_config.failed_jobs_history_limit`
 
 [horizontal]
 type:: string
@@ -206,6 +212,7 @@ This allows users to make alert expressions configurable without having to copy-
 type:: dict
 default::
 +
+[subs=+quotes]
 [source,yaml]
 ----
 k8up_last_errors:
@@ -215,10 +222,10 @@ k8up_last_errors:
   for: 1m
   labels:
     severity: critical
-K8upBackupFailed:
+K8up**OBJECT_TYPE**Failed:
   annotations:
-    message: Job in {{ $labels.exported_namespace }} of type {{ $labels.jobType }} failed
-  expr: rate(k8up_jobs_failed_counter[1d]) > 0
+    summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
+  expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="**OBJECT_TYPE**"}) > 0
   for: 1m
   labels:
     severity: critical
@@ -255,7 +262,6 @@ This structure is chosen to easily adjust individual alert configurations in the
 [source,yaml]
 ----
 namespace: example-namespace
-global_keepjobs: "1"
 global_s3_credentials:
   accesskey: '?{vaultkv:${cluster:tenant}/${cluster:name}/global-backup/access-key}'
   secretkey: '?{vaultkv:${cluster:tenant}/${cluster:name}/global-backup/secret-key}'

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -227,19 +227,24 @@ This allows users to make alert expressions configurable without having to copy-
 
 [horizontal]
 type:: dict
-default:: See https://github.com/projectsyn/component-backup-k8up/blob/master/class/defaults.yml
+valid keys:: `['archive', 'backup', 'check', 'prune', 'restore']`
+default:: [See `class/defaults.yml`|https://github.com/projectsyn/component-backup-k8up/blob/master/class/defaults.yml]
 
-Dict that creates JobFailed alert rules for the given types of jobs.
+Dict which controls the set of JobFailed alert rules to create.
 Valid keys are `archive`, `backup`, `check`, `prune`, and `restore`.
-`enabled: false` removes the alert rule.
-Overrides can override all fields from the `job_failed_alert_template`.
+The value for each key is expected to be a dict with keys `enabled` and `overrides`.
+The value for key `enabled` should be a boolean.
+This key controls whether the corresponding alert rule is created.
+The value for key `overrides` is merged with the object configured in `job_failed_alert_template`.
+When configuring overrides, Jsonnet merges arrays and objects from the template with their counterparts in `overrides`.
+This key allows users to customize any alert properties for individual `JobFailed` alerts.
 The fields are overridden before interpolating `%(type)s`.
 
 == `job_failed_alert_template`
 
 [horizontal]
 type:: dict
-default:: See https://github.com/projectsyn/component-backup-k8up/blob/master/class/defaults.yml
+default:: [See `class/defaults.yml`|https://github.com/projectsyn/component-backup-k8up/blob/master/class/defaults.yml]
 
 The template for the JobFailed alert rules.
 %(type)s in `alert` and `expr` is replaced by the types defined in `job_failed_alerts_for`.
@@ -248,7 +253,7 @@ The template for the JobFailed alert rules.
 
 [horizontal]
 type:: dict
-default:: See https://github.com/projectsyn/component-backup-k8up/blob/master/class/defaults.yml
+default:: [See `class/defaults.yml`|https://github.com/projectsyn/component-backup-k8up/blob/master/class/defaults.yml]
 
 Alert definitions to deploy in a `PrometheusRule` object.
 The dict is transformed to a list of alerting rules by the component.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -214,6 +214,27 @@ This allows users to make alert expressions configurable without having to copy-
 
 * `k8up_slow_backup_job_duration_seconds` configures the threshold in seconds above which alerts are generated for "slow" backup jobs.
 
+== `job_failed_alerts_for`
+
+[horizontal]
+type:: dict
+default:: See https://github.com/projectsyn/component-backup-k8up/blob/master/class/defaults.yml
+
+Dict that creates JobFailed alert rules for the given types of jobs.
+Valid keys are `archive`, `backup`, `check`, `prune`, and `restore`.
+`enabled: false` removes the alert rule.
+Overrides can override all fields from the `job_failed_alert_template`.
+The fields are overridden before interpolating `%(type)s`.
+
+== `job_failed_alert_template`
+
+[horizontal]
+type:: dict
+default:: See https://github.com/projectsyn/component-backup-k8up/blob/master/class/defaults.yml
+
+The template for the JobFailed alert rules.
+%(type)s in `alert` and `expr` is replaced by the types defined in `job_failed_alerts_for`.
+
 == `monitoring_alerts`
 
 [horizontal]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -113,17 +113,25 @@ default:: `null`
 type:: string
 default:: `null`
 
-== `global_backup_config.successful_jobs_history_limit`
+== `global_backup_config.keepjobs`
 
 [horizontal]
 type:: string
 default:: `3`
+
+Deprecated: Use `global_backup_config.successful_jobs_history_limit` and `global_backup_config.failed_jobs_history_limit` instead.
+
+== `global_backup_config.successful_jobs_history_limit`
+
+[horizontal]
+type:: string
+default:: ``
 
 == `global_backup_config.failed_jobs_history_limit`
 
 [horizontal]
 type:: string
-default:: `3`
+default:: ``
 
 == `global_backup_config.stats_endpoint`
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -267,14 +267,17 @@ This structure is chosen to easily adjust individual alert configurations in the
 [source,yaml]
 ----
 namespace: example-namespace
-global_s3_credentials:
-  accesskey: '?{vaultkv:${cluster:tenant}/${cluster:name}/global-backup/access-key}'
-  secretkey: '?{vaultkv:${cluster:tenant}/${cluster:name}/global-backup/secret-key}'
-global_s3restore_credentials:
-  accesskey: '?{vaultkv:${cluster:tenant}/${cluster:name}/global-backup/restore-access-key}'
-  secretkey: '?{vaultkv:${cluster:tenant}/${cluster:name}/global-backup/restore-secret-key}'
-global_restore_s3endpoint: https://s3endpoint.example.com
-global_restore_bucket: example-restore-bucket
+global_backup_config:
+  successful_jobs_history_limit: 1
+  failed_jobs_history_limit: 1
+  s3_credentials:
+    accesskey: '?{vaultkv:${cluster:tenant}/${cluster:name}/global-backup/access-key}'
+    secretkey: '?{vaultkv:${cluster:tenant}/${cluster:name}/global-backup/secret-key}'
+  s3restore_credentials:
+    accesskey: '?{vaultkv:${cluster:tenant}/${cluster:name}/global-backup/restore-access-key}'
+    secretkey: '?{vaultkv:${cluster:tenant}/${cluster:name}/global-backup/restore-secret-key}'
+  restore_s3endpoint: https://s3endpoint.example.com
+  restore_bucket: example-restore-bucket
 monitoring_alerts:
   K8upJobStuck:
     annotations:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -218,47 +218,7 @@ This allows users to make alert expressions configurable without having to copy-
 
 [horizontal]
 type:: dict
-default::
-+
-[subs=+quotes]
-[source,yaml]
-----
-k8up_last_errors:
-  annotations:
-    message: Last backup for PVC {{ $labels.pvc }} in namespace {{ $labels.instance }} had {{ $value }} errors
-  expr: baas_backup_restic_last_errors{${backup_k8up:alert_rule_filters:namespace}} > 0
-  for: 1m
-  labels:
-    severity: critical
-K8up**OBJECT_TYPE**Failed:
-  annotations:
-    summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type }} failed
-  expr: (sum(kube_job_status_failed) by(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) * on(${backup_k8up:monitoring_kube_state_metrics_job_name_label}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="**OBJECT_TYPE**"}) > 0
-  for: 1m
-  labels:
-    severity: critical
-K8upBackupNotRunning:
-  annotations:
-    message: No K8up jobs were run in {{ $labels.exported_namespace }} within the last 24 hours. Check the operator, there might be a deadlock
-  expr: sum(rate(k8up_jobs_total[25h])) == 0 and on(namespace) k8up_schedules_gauge > 0
-  for: 1m
-  labels:
-    severity: critical
-K8upJobStuck:
-  annotations:
-    message: Queued K8up jobs in {{ $labels.exported_namespace }} for the last hour.
-  expr: k8up_jobs_queued_gauge{jobType="backup"} > 0 and on(namespace) k8up_schedules_gauge > 0
-  for: 1h
-  labels:
-    severity: critical
-K8upSlowBackup:
-  annotations:
-    message: Backup job {{ $labels.job_name }} in {{ $labels.namespace }} took {{ $value|humanizeDuration }} to complete
-  expr: (kube_job_status_completion_time{job_name=~"^backupjob-.*$"} - kube_job_status_start_time) > ${backup_k8up:alert_thresholds:k8up_slow_backup_job_duration_seconds}
-  for: 1m
-  labels:
-    severity: warning
-----
+default:: See https://github.com/projectsyn/component-backup-k8up/blob/master/class/defaults.yml
 
 Alert definitions to deploy in a `PrometheusRule` object.
 The dict is transformed to a list of alerting rules by the component.


### PR DESCRIPTION
This PR upgrades the `k8up` helm chart to `v1.1.0` and the underlying `k8up` to `v1.2.0`.

It takes the new alert rules from the updated helm chart and replaces the `keepjobs` field with the new `failedJobsHistoryLimit` and `successfulJobsHistoryLimit` fields.

⚠️ https://github.com/vshn/k8up/pull/471 should be merged first to have proper, working links.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
