### PR TITLE
Deprecate 'enabled' parameter

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,9 +1,5 @@
 parameters:
   backup_k8up:
-    # This switch is required to selectively disable the component
-    # TODO: Reevaluate the need for this once we can remove components
-    # See: https://github.com/projectsyn/commodore/issues/71
-    enabled: true
 
     charts:
       k8up: 1.1.0

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -89,6 +89,10 @@ local app = argocd.App('backup-k8up', params.namespace) {
   },
 };
 
-if params.enabled then {
+local enabled = if std.objectHas(params, 'enabled') then
+  params.enabled
+else
+  true;
+if enabled then {
   backup: app,
 } else {}

--- a/docs/modules/ROOT/pages/how-tos/upgrade-v2-v3.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-v2-v3.adoc
@@ -1,0 +1,18 @@
+= Upgrade component from v2 to v3
+
+K8up v2.0.0 and also the respective Helm chart v2.0.0 introduced breaking changes that also affect this component.
+The upgrade process of K8up itself is documented here: https://k8up.io/k8up/2.0/how-tos/upgrade.html.
+Contrary to the Helm chart, this component already ships the necessary CRDs.
+
+== Parameter changes
+
+- `enabled` parameter is **deprecated**.
+  This parameter was used as a temporary workaround to disable a component until Commodore could do it natively.
+
+== Steps
+
+. Update component parameters in cluster config as outlined in section <<_parameter_changes,parameter changes>>
+
+. Update component version for the cluster
+
+. Compile and push cluster catalog

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -5,6 +5,8 @@ The parent key for all of the following parameters is `backup_k8up`.
 
 == `enabled`
 
+NOTE: This parameter is **deprecated**
+
 [horizontal]
 type:: bool
 default:: `true`

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,3 +1,8 @@
 * xref:index.adoc[Home]
+
+.How-tos
 * xref:how-tos/upgrade-v1-v2.adoc[Upgrade component from v1 to v2]
+* xref:how-tos/upgrade-v2-v3.adoc[Upgrade component from v2 to v3]
+
+.Reference
 * xref:references/parameters.adoc[Parameters]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,1 +1,1 @@
-
+# Default parameters


### PR DESCRIPTION
* Deprecates `enabled` parameter. Recent Commodore versions can do it natively, but there are cases where this parameter is still used for legacy reasons.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
