### PR TITLE
Document step to cleanup CRDs of v1 after upgrade

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/upgrade-v2-v3.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-v2-v3.adoc
@@ -118,3 +118,14 @@ IMPORTANT: This will already recreate K8up resources managed in other components
 <2> Overriding the Helm release name isn't necessary anymore
 
 . Compile and push cluster catalog.
+
+. Delete the K8up v1 CRDs
++
+[source,bash]
+----
+for crd in archives.backup.appuio.ch backups.backup.appuio.ch checks.backup.appuio.ch prebackuppods.backup.appuio.ch prunes.backup.appuio.ch restores.backup.appuio.ch schedules.backup.appuio.ch; do
+  kubectl delete crd "${crd}"
+done
+----
++
+NOTE: This will delete all remaining K8up v1 resources!


### PR DESCRIPTION
* Adds step after upgrade to forEach `kubectl delete crd`. This should ensure that users cannot create K8up v1 resources anymore after upgrade (e.g. via outdated forgotten pipeline).

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
