### PR TITLE
Set correct monitoring label on namespace for OCP4

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -27,14 +27,23 @@ local global_backup_secret = kube.Secret(params.global_backup_config.backup_secr
 
 local monitoring = import 'monitoring.jsonnet';
 
+local monitoring_labels =
+  if inv.parameters.facts.distribution == 'openshift4' then
+    {
+
+      'openshift.io/cluster-monitoring': 'true',
+    }
+  else
+    {
+      SYNMonitoring: 'main',
+    };
+
 local want_global_config = params.global_backup_config.enabled && params.global_backup_config.s3_endpoint != null;
 
 {
   '00_namespace': kube.Namespace(params.namespace) {
     metadata+: {
-      labels+: {
-        SYNMonitoring: 'main',
-      },
+      labels+: monitoring_labels,
     },
   },
   [if want_global_config then '10_global_s3_credentials']:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -224,6 +224,8 @@ It's suggested to do this within you global configuration hierarchy.
 type:: bool
 default:: `true`
 
+For most Kubernetes distributions, the component sets label `SYNMonitoring=main` on the namespace in which K8up is deployed.
+On OpenShift 4, the component sets label `openshift.io/cluster-monitoring=true` on the namespace instead, so that the K8up `ServiceMonitor` and `PrometheusRule` objects are picked up by the OpenShift 4 cluster monitoring stack.
 
 == `alert_thresholds`
 


### PR DESCRIPTION
For OpenShift 4, the namespace needs to be labeled with `openshift.io/cluster-monitoring=true` for the `PrometheusRule` and `ServiceMonitor` objects to be picked up by OpenShift cluster-monitoring.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
