### PR TITLE
Omit `promURL` in K8up resources if `prometheus_push_gateway` is `null`

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -202,6 +202,9 @@ default:: `{'namespace': 'namespace=~"syn.*"'}
 type:: string
 default:: `'http://platform-prometheus-pushgateway.syn-synsights.svc:9091'`
 
+Set this parameter to `null` to configure the component to not set the pushgateway URL.
+Setting the parameter to `null` ensures that the environment variable `BACKUP_PROMURL` is never set for the K8up deployment and that the component library won't set the field `promURL` in any K8up custom resources.
+
 == `prometheus_name`
 
 [horizontal]

--- a/lib/backup-k8up.libjsonnet
+++ b/lib/backup-k8up.libjsonnet
@@ -79,7 +79,8 @@ local CheckSpec(schedule) =
   {
     spec+: {
       check: {
-        promURL: k8up_params.prometheus_push_gateway,
+        [if k8up_params.prometheus_push_gateway != null then 'promURL']:
+          k8up_params.prometheus_push_gateway,
         schedule: schedule,
       },
     },
@@ -183,7 +184,8 @@ local Schedule(name, schedule, keep_jobs=3, backupkey=null, bucket=null, s3secre
       spec: {
         backend: backend.spec,
         backup: {
-          promURL: k8up_params.prometheus_push_gateway,
+          [if k8up_params.prometheus_push_gateway != null then 'promURL']:
+            k8up_params.prometheus_push_gateway,
           keepJobs: keep_jobs,
           schedule: schedule,
         },


### PR DESCRIPTION
We add logic to omit field `promURL` from K8up resources (schedules and checks) if the user sets `parameters.backup_k8up.prometheus_push_gateway` to `null`.

Additionally, we document how the component handles a `null` value for the parameter.

Fixes #12




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
