### PR TITLE
Fix Helm chart dependency directory

### DIFF
--- a/class/backup-k8up.yml
+++ b/class/backup-k8up.yml
@@ -5,7 +5,7 @@ parameters:
         source: ${backup_k8up:charts:k8up:source}
         chart_name: k8up
         version: ${backup_k8up:charts:k8up:version}
-        output_path: dependencies/backup-k8up/helmcharts/v${backup_k8up:charts:k8up}
+        output_path: dependencies/backup-k8up/helmcharts/v${backup_k8up:charts:k8up:version}
       - type: https
         source: https://github.com/vshn/k8up/releases/download/${backup_k8up:_k8upImage:${backup_k8up:majorVersion}:tag}/${backup_k8up:crd}
         output_path: dependencies/backup-k8up/crds/${backup_k8up:_k8upImage:${backup_k8up:majorVersion}:tag}/02_k8up_crds.yaml
@@ -23,7 +23,7 @@ parameters:
         input_type: helm
         output_type: yaml
         input_paths:
-          - backup-k8up/helmcharts/v${backup_k8up:charts:k8up}
+          - backup-k8up/helmcharts/v${backup_k8up:charts:k8up:version}
         helm_values: ${backup_k8up:helmValues}
         helm_params:
           name: ${backup_k8up:helmReleaseName}


### PR DESCRIPTION
We want to use `backup_k8up:charts:k8up:version` for specifying the Helm chart dependency output directory with the new Helm chart configuration structure.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
