### PR TITLE
Restructure K8up image specification

### DIFF
--- a/class/backup-k8up.yml
+++ b/class/backup-k8up.yml
@@ -7,15 +7,15 @@ parameters:
         version: ${backup_k8up:charts:k8up:version}
         output_path: dependencies/backup-k8up/helmcharts/v${backup_k8up:charts:k8up:version}
       - type: https
-        source: https://github.com/vshn/k8up/releases/download/${backup_k8up:_k8upImage:${backup_k8up:majorVersion}:tag}/${backup_k8up:crd}
-        output_path: dependencies/backup-k8up/crds/${backup_k8up:_k8upImage:${backup_k8up:majorVersion}:tag}/02_k8up_crds.yaml
+        source: https://github.com/vshn/k8up/releases/download/${backup_k8up:images:k8up:tag}/${backup_k8up:crd}
+        output_path: dependencies/backup-k8up/crds/${backup_k8up:images:k8up:tag}/02_k8up_crds.yaml
     compile:
       - input_paths:
           - backup-k8up/component/app.jsonnet
         input_type: jsonnet
         output_path: apps/
       - input_paths:
-          - backup-k8up/crds/${backup_k8up:_k8upImage:${backup_k8up:majorVersion}:tag}/
+          - backup-k8up/crds/${backup_k8up:images:k8up:tag}/
         output_path: ${_instance}
         input_type: copy
         output_type: yaml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -14,7 +14,11 @@ parameters:
         registry: ghcr.io
         repository: k8up-io/k8up
         tag: v1.2.0
-      v2: ${backup_k8up:images:k8up}
+      v2:
+        registry: ghcr.io
+        repository: k8up-io/k8up
+        tag: v2.4.0
+        pullPolicy: IfNotPresent
     =_chartVersion:
       v1: 1.1.0
       v2: 3.0.0
@@ -34,11 +38,7 @@ parameters:
         version: ${backup_k8up:_chartVersion:${backup_k8up:majorVersion}}
 
     images:
-      k8up:
-        registry: ghcr.io
-        repository: k8up-io/k8up
-        tag: v2.4.0
-        pullPolicy: IfNotPresent
+      k8up: ${backup_k8up:_k8upImage:${backup_k8up:majorVersion}}
       # This image is deprecated since K8up v2 support
       wrestic:
         registry: ghcr.io
@@ -54,7 +54,7 @@ parameters:
 
     helmValues:
       replicaCount: 1
-      image: ${backup_k8up:_k8upImage:${backup_k8up:majorVersion}}
+      image: ${backup_k8up:images:k8up}
       k8up:
         enableLeaderElection: true
         timezone: "Etc/UTC"


### PR DESCRIPTION
We restructure the K8up container image specification to populate `backup_k8up:images:k8up` from the lookup table containing the default image versions for K8up v1.x and v2.x instead of populating v2 of the lookup table from `backup_k8up:images:k8up`.

While breaking the Commodore component best practices, this brings the container image specification in line with the Helm chart specification and restructures the class enough to avoid running into a bug when resolving nested references in reclass which we hit with the old structure

See https://github.com/kapicorp/reclass/pull/8 for a potential fix of the underlying reclass bug.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
