### PR TITLE
Add syn labels to alert rules

### DIFF
--- a/tests/golden/v1/backup-k8up/backup-k8up/30_monitoring.yaml
+++ b/tests/golden/v1/backup-k8up/backup-k8up/30_monitoring.yaml
@@ -19,6 +19,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upJobStuck
           annotations:
             message: Queued K8up jobs in {{ $labels.exported_namespace }} for the
@@ -28,6 +30,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upSlowBackup
           annotations:
             message: Backup job {{ $labels.job_name }} in {{ $labels.namespace }}
@@ -37,6 +41,8 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: k8up_last_errors
           annotations:
             message: Last backup for PVC {{ $labels.pvc }} in namespace {{ $labels.instance
@@ -45,6 +51,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upArchiveFailed
           annotations:
             summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type
@@ -55,6 +63,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upBackupFailed
           annotations:
             summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type
@@ -65,6 +75,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upCheckFailed
           annotations:
             summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type
@@ -75,6 +87,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upPruneFailed
           annotations:
             summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type
@@ -85,6 +99,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upRestoreFailed
           annotations:
             summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type
@@ -95,6 +111,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/tests/golden/v2/backup-k8up/backup-k8up/30_monitoring.yaml
+++ b/tests/golden/v2/backup-k8up/backup-k8up/30_monitoring.yaml
@@ -19,6 +19,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upJobStuck
           annotations:
             message: Queued K8up jobs in {{ $labels.exported_namespace }} for the
@@ -28,6 +30,8 @@ spec:
           for: 1h
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upSlowBackup
           annotations:
             message: Backup job {{ $labels.job_name }} in {{ $labels.namespace }}
@@ -37,6 +41,8 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: k8up_last_errors
           annotations:
             message: Last backup for PVC {{ $labels.pvc }} in namespace {{ $labels.instance
@@ -45,6 +51,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upArchiveFailed
           annotations:
             summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type
@@ -55,6 +63,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upBackupFailed
           annotations:
             summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type
@@ -65,6 +75,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upCheckFailed
           annotations:
             summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type
@@ -75,6 +87,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upPruneFailed
           annotations:
             summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type
@@ -85,6 +99,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
         - alert: K8upRestoreFailed
           annotations:
             summary: Job in {{ $labels.namespace }} of type {{ $labels.label_k8up_syn_tools_type
@@ -95,6 +111,8 @@ spec:
           for: 1m
           labels:
             severity: critical
+            syn: 'true'
+            syn_component: backup-k8up
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
Some components base their alert routing on the existence of the `syn` label and the `syn_component` label can be useful during troubleshooting.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
