### PR TITLE
Add monitoring labels to support component-prometheus

### DIFF
--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,5 +57,5 @@ KUBENT_ARGS     ?= -c=false --helm2=false --helm3=false -e
 KUBENT_IMAGE    ?= docker.io/projectsyn/kubent:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
-instance ?= defaults
+instance ?= v2
 test_instances = tests/v1.yml tests/v2.yml

--- a/component/monitoring.jsonnet
+++ b/component/monitoring.jsonnet
@@ -1,6 +1,8 @@
 local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
+local prometheus = import 'lib/prometheus.libsonnet';
+
 local inv = kap.inventory();
 local params = inv.parameters.backup_k8up;
 
@@ -87,4 +89,18 @@ local alert_rules = com.namespaced(params.namespace, {
   },
 });
 
-[ alert_rules, service_monitor ]
+local final_alert_rules =
+  if std.member(inv.applications, 'prometheus') then
+    prometheus.Enable(alert_rules)
+  else
+    alert_rules
+;
+
+local final_service_monitor =
+  if std.member(inv.applications, 'prometheus') then
+    prometheus.Enable(service_monitor)
+  else
+    service_monitor
+;
+
+[ final_alert_rules, final_service_monitor ]

--- a/tests/golden/v2/backup-k8up/backup-k8up/00_namespace.yaml
+++ b/tests/golden/v2/backup-k8up/backup-k8up/00_namespace.yaml
@@ -4,5 +4,6 @@ metadata:
   annotations: {}
   labels:
     SYNMonitoring: main
+    monitoring.syn.tools/infra: 'true'
     name: syn-backup-k8up
   name: syn-backup-k8up

--- a/tests/golden/v2/backup-k8up/backup-k8up/30_monitoring.yaml
+++ b/tests/golden/v2/backup-k8up/backup-k8up/30_monitoring.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
+    monitoring.syn.tools/enabled: 'true'
     prometheus: main
     role: alert-rules
   name: k8up
@@ -120,6 +121,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: k8up
     app.kubernetes.io/name: k8up
+    monitoring.syn.tools/enabled: 'true'
     prometheus: main
   name: k8up-operator
   namespace: syn-backup-k8up

--- a/tests/v2.yml
+++ b/tests/v2.yml
@@ -1,1 +1,12 @@
-# using defaults
+applications:
+  - prometheus
+
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
+        output_path: vendor/lib/prometheus.libsonnet
+
+  prometheus:
+    defaultInstance: infra


### PR DESCRIPTION
The component `prometheus` supports cluster-monitoring, where the namespace, PrometheusRules and monitors need a specific label.

This commit will add the required labels.

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>




## Checklist

- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
