### PR TITLE
Enable ignoring individual default alert rules

### DIFF
--- a/component/monitoring.jsonnet
+++ b/component/monitoring.jsonnet
@@ -83,6 +83,7 @@ local alert_rules = com.namespaced(params.namespace, {
             labels+: alertlabels,
           }
           for field in std.sort(std.objectFields(params.monitoring_alerts))
+          if params.monitoring_alerts[field] != null
         ] + failed_job_alert_rules,
       },
     ],

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -282,6 +282,7 @@ Alert definitions to deploy in a `PrometheusRule` object.
 The dict is transformed to a list of alerting rules by the component.
 Keys in the dict are used to add the field `alert: <key>` to each resulting alerting rule.
 This structure is chosen to easily adjust individual alert configurations in the hierarchy.
+Individual alerts can be excluded by setting their value to `null`.
 
 == Example
 


### PR DESCRIPTION
Adds the possibility to exclude individual alert rules from class/defaults.yml by setting their value to `null`

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
