### PR TITLE
Make Helm chart cleanup job container image configurable

### DIFF
--- a/class/backup-k8up.yml
+++ b/class/backup-k8up.yml
@@ -39,3 +39,6 @@ parameters:
         - type: jsonnet
           filter: postprocess/optional_global_config.jsonnet
           path: ${_instance}/01_k8up_helmchart/k8up/templates
+        - type: jsonnet
+          filter: postprocess/cleanup-job.jsonnet
+          path: ${_instance}/01_k8up_helmchart/k8up/templates

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -11,6 +11,10 @@ parameters:
         repository: k8up-io/k8up
         tag: v2.7.1
         pullPolicy: IfNotPresent
+      kubectl:
+        registry: docker.io
+        repository: bitnami/kubectl
+        tag: latest
 
     helmReleaseName: k8up
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -17,7 +17,7 @@ The default K8up Helm chart version to use.
 type:: dict
 default:: See `class/defaults.yml`
 
-The default Docker image location and tag to use for K8up (key `k8up`).
+The default Docker image location and tag to use for K8up (key `k8up`) and kubectl (key `kubectl`).
 
 Entries in this dict should be dictionaries with keys `registry`, `repository`, and `tag`.
 This structure provides the basis for https://syn.tools/syn/SDDs/0017-maintenance-with-renovate.html[dependency maintenance with Renovate].
@@ -25,6 +25,9 @@ This structure provides the basis for https://syn.tools/syn/SDDs/0017-maintenanc
 Please customize K8up image location and tag in this dict instead of directly in `helmValues`.
 
 The value of `k8up.tag` in this dict is used by the component to select the CRD YAML to download.
+
+The component uses the contents of field `kubectl` to patch the Helm chart's cleanup job.
+This allows users to configure a custom location for the `kubectl` image used by the job.
 
 == `helmValues`
 

--- a/postprocess/cleanup-job.jsonnet
+++ b/postprocess/cleanup-job.jsonnet
@@ -1,0 +1,28 @@
+local com = import 'lib/commodore.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = com.inventory();
+local params = inv.parameters.backup_k8up;
+
+local chart_output_dir = std.extVar('output_path');
+
+local patch_registry(obj) =
+  if obj.kind == 'Job' then
+    obj {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: [
+              c {
+                image: '%(registry)s/%(repository)s:%(tag)s' % params.images.kubectl,
+              }
+              for c in super.containers
+            ],
+          },
+        },
+      },
+    }
+  else
+    obj;
+
+com.fixupDir(chart_output_dir, patch_registry)

--- a/tests/golden/defaults/backup-k8up/backup-k8up/01_k8up_helmchart/k8up/templates/cleanup-hook.yaml
+++ b/tests/golden/defaults/backup-k8up/backup-k8up/01_k8up_helmchart/k8up/templates/cleanup-hook.yaml
@@ -100,7 +100,7 @@ spec:
           command:
             - sh
             - -c
-          image: bitnami/kubectl:latest
+          image: docker.io/bitnami/kubectl:latest
           name: k8up-cleanup
       restartPolicy: Never
       serviceAccountName: cleanup-service-account


### PR DESCRIPTION
We `parameters.backup_k8up.images.kubectl` and add a postprocessing filter which patches the cleanup job to use the image location specified in that image parameter.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
