### PR TITLE
Fix misconfigured helm value for `skipWithoutAnnotation`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -33,6 +33,8 @@ parameters:
           repository: ${backup_k8up:images:k8up:registry}/${backup_k8up:images:k8up:repository}
           tag: ${backup_k8up:images:k8up:tag}
 
+        skipWithoutAnnotation: ${backup_k8up:global_backup_config:skip_without_annotation}
+
         envVars:
           - name: BACKUP_PROMURL
             value: '${backup_k8up:prometheus_push_gateway}'
@@ -81,8 +83,6 @@ parameters:
             value: '${backup_k8up:global_backup_config:restore_bucket}'
           - name: BACKUP_GLOBALRESTORES3ENDPOINT
             value: '${backup_k8up:global_backup_config:restore_s3endpoint}'
-          - name: BACKUP_SKIP_WITHOUT_ANNOTATION
-            value: '${backup_k8up:global_backup_config:skip_without_annotation}'
 
     global_backup_config:
       enabled: true

--- a/tests/golden/defaults/backup-k8up/backup-k8up/01_k8up_helmchart/k8up/templates/deployment.yaml
+++ b/tests/golden/defaults/backup-k8up/backup-k8up/01_k8up_helmchart/k8up/templates/deployment.yaml
@@ -43,8 +43,6 @@ spec:
               value: k8up.io/backupcommand
             - name: BACKUP_BACKOFFLIMIT
               value: '2'
-            - name: BACKUP_SKIP_WITHOUT_ANNOTATION
-              value: false
           image: ghcr.io/k8up-io/k8up:v2.10.0
           imagePullPolicy: IfNotPresent
           livenessProbe:


### PR DESCRIPTION
`skipWithoutAnnotation` is a helm value, not an envvar

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
