### PR TITLE
Revert "Fix missing finalizers in the ArgoCD app"

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -11,13 +11,5 @@ local appPath =
   if project == 'syn' then 'apps' else 'apps-%s' % project;
 
 {
-  ['%s/backup-k8up' % appPath]: app {
-    metadata+: {
-      finalizers: [
-        'resources-finalizer.argocd.argoproj.io',
-        'post-delete-finalizer.argocd.argoproj.io',
-        'post-delete-finalizer.argocd.argoproj.io/cleanup'
-      ],
-    },
-  },
+  ['%s/backup-k8up' % appPath]: app,
 }

--- a/tests/golden/defaults/backup-k8up/apps/backup-k8up.yaml
+++ b/tests/golden/defaults/backup-k8up/apps/backup-k8up.yaml
@@ -1,5 +1,0 @@
-metadata:
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
-    - post-delete-finalizer.argocd.argoproj.io
-    - post-delete-finalizer.argocd.argoproj.io/cleanup


### PR DESCRIPTION
With https://github.com/projectsyn/component-argocd/pull/287 we shouldn't need to manage the dynamically added ArgoCD finalizers on the ArgoCD app anymore.

This reverts commit e6760450473d839a12937a4e4da1d18c7ef816b6.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
